### PR TITLE
Revert x tick refactor

### DIFF
--- a/lib/components/AreaChart/AreaChart.vue
+++ b/lib/components/AreaChart/AreaChart.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts" generic="T">
 import { computed, createApp } from "vue";
-import {
-  type NumericAccessor,
-  CurveType,
-  Position,
-} from "@unovis/ts";
+import { type NumericAccessor, CurveType, Position } from "@unovis/ts";
 import {
   VisArea,
   VisAxis,
@@ -73,15 +69,6 @@ const svgDefs = colors
 const LegendPositionTop = computed(
   () => props.legendPosition === LegendPosition.Top
 );
-
-const tickIndices = computed(() =>  getDistributedIndices(props.data.length, props.xNumTicks))
-
-const filteredDataByIndices = computed(() => {
-  if (!props.data?.length || !tickIndices || tickIndices.value.length === 0) {
-    return [];
-  }
-  return tickIndices.value.map((index) => props.data[index]);
-})
 </script>
 
 <template>
@@ -89,7 +76,7 @@ const filteredDataByIndices = computed(() => {
     class="flex flex-col space-y-4"
     :class="{ 'flex-col-reverse': LegendPositionTop }"
   >
-    <VisXYContainer :data="filteredDataByIndices" :height="height" :svg-defs="svgDefs">
+    <VisXYContainer :data="data" :height="height" :svg-defs="svgDefs">
       <VisTooltip
         v-if="!hideTooltip"
         :horizontal-placement="Position.Right"
@@ -112,11 +99,11 @@ const filteredDataByIndices = computed(() => {
       </template>
 
       <VisAxis
-        type="x"
-        :num-ticks="filteredDataByIndices.length"
-        :tick-format="(i: number, idx: number) => xFormatter(filteredDataByIndices[i], idx)"
+        :tick-format="xFormatter"
         :label="xLabel"
         :grid-line="xGridLine"
+        :num-ticks="xNumTicks"
+        :tick-values="xExplicitTicks"
         :domain-line="xDomainLine"
         :tick-line="!!xGridLine"
       />

--- a/lib/components/AreaChart/types.ts
+++ b/lib/components/AreaChart/types.ts
@@ -2,83 +2,87 @@ import { LegendPosition } from "../../types";
 import type { BulletLegendItemInterface, CurveType } from "@unovis/ts";
 
 export interface AreaChartProps<T> {
-    /**
-     * The data to be displayed in the area chart.
-     * Each element of the array represents a data point.
-     * The structure of 'T' should be compatible with the chart's rendering logic.
-     */
-    data: T[];
-    /**
-     * The height of the chart in pixels.
-     */
-    height: number;
-    /**
-     * Optional label for the x-axis.
-     */
-    xLabel?: string;
-    /**
-     * Optional label for the y-axis.
-     */
-    yLabel?: string;
-    /**
-     * A record mapping category keys to `BulletLegendItemInterface` objects.
-     * This defines the visual representation and labels for each category in the chart's legend.
-     */
-    categories: Record<string, BulletLegendItemInterface>;
-    /**
-     * A function that formats the x-axis tick labels.
-     * @param item The x-axis value to be formatted.
-     * @param idx The index of the data point.
-     * @returns The formatted x-axis label.
-     */
-    xFormatter: (item: T, idx: number) => string | number;
-    /**
-     * An optional function that formats the y-axis tick labels.
-     * @param i The value to be formatted.
-     * @param idx The index of the data point (optional).
-     * @returns The formatted y-axis label or value.
-     */
-    yFormatter?: (i: number, idx?: number) => string | number;
-    /**
-     * The type of curve to use for the area chart lines.
-     * See `CurveType` for available options.
-     */
-    curveType?: CurveType;
-    /**
-     * The desired number of ticks on the x-axis.
-     */
-    xNumTicks?: number;
-    /**
-     * The desired number of ticks on the y-axis.
-     */
-    yNumTicks?: number;
-    /**
-     * If `true`, hides the chart legend.
-     */
-    hideLegend?: boolean;
-    /**
-     * If `true`, hides the chart tooltip.
-     */
-    hideTooltip?: boolean;
-    /**
-     * If `true`, displays grid lines along the x-axis.
-     */
-    xGridLine?: boolean;
-    /**
-     * If `true`, displays a domain line (axis line) along the x-axis.
-     */
-    xDomainLine?: boolean;
-    /**
-     * If `true`, displays grid lines along the y-axis.
-     */
-    yGridLine?: boolean;
-    /**
-     * If `true`, displays a domain line (axis line) along the y-axis.
-     */
-    yDomainLine?: boolean;
-    /**
-     * Optional position for the legend, if applicable.
-     * See `LegendPosition` for available options.
-     */
-    legendPosition?: LegendPosition;
-  };
+  /**
+   * The data to be displayed in the area chart.
+   * Each element of the array represents a data point.
+   * The structure of 'T' should be compatible with the chart's rendering logic.
+   */
+  data: T[];
+  /**
+   * The height of the chart in pixels.
+   */
+  height: number;
+  /**
+   * Optional label for the x-axis.
+   */
+  xLabel?: string;
+  /**
+   * Optional label for the y-axis.
+   */
+  yLabel?: string;
+  /**
+   * A record mapping category keys to `BulletLegendItemInterface` objects.
+   * This defines the visual representation and labels for each category in the chart's legend.
+   */
+  categories: Record<string, BulletLegendItemInterface>;
+  /**
+   * A function that formats the x-axis tick labels.
+   * @param item The x-axis value to be formatted.
+   * @param idx The index of the data point.
+   * @returns The formatted x-axis label.
+   */
+  xFormatter: (item: T, idx: number) => string | number;
+  /**
+   * An optional function that formats the y-axis tick labels.
+   * @param i The value to be formatted.
+   * @param idx The index of the data point (optional).
+   * @returns The formatted y-axis label or value.
+   */
+  yFormatter?: (i: number, idx?: number) => string | number;
+  /**
+   * The type of curve to use for the area chart lines.
+   * See `CurveType` for available options.
+   */
+  curveType?: CurveType;
+  /**
+   * The desired number of ticks on the x-axis.
+   */
+  xNumTicks?: number;
+  /**
+   * Force specific ticks on the x-axis.
+   */
+  xExplicitTicks?: number;
+  /**
+   * The desired number of ticks on the y-axis.
+   */
+  yNumTicks?: number;
+  /**
+   * If `true`, hides the chart legend.
+   */
+  hideLegend?: boolean;
+  /**
+   * If `true`, hides the chart tooltip.
+   */
+  hideTooltip?: boolean;
+  /**
+   * If `true`, displays grid lines along the x-axis.
+   */
+  xGridLine?: boolean;
+  /**
+   * If `true`, displays a domain line (axis line) along the x-axis.
+   */
+  xDomainLine?: boolean;
+  /**
+   * If `true`, displays grid lines along the y-axis.
+   */
+  yGridLine?: boolean;
+  /**
+   * If `true`, displays a domain line (axis line) along the y-axis.
+   */
+  yDomainLine?: boolean;
+  /**
+   * Optional position for the legend, if applicable.
+   * See `LegendPosition` for available options.
+   */
+  legendPosition?: LegendPosition;
+}

--- a/lib/components/BarChart/BarChart.vue
+++ b/lib/components/BarChart/BarChart.vue
@@ -19,7 +19,6 @@ import {
 import Tooltip from "./../Tooltip.vue";
 import { LegendPosition } from "../../types";
 import { BarChartProps } from "./types";
-import { getDistributedIndices } from "../../utils";
 
 const props = withDefaults(defineProps<BarChartProps<T>>(), {
   orientation: Orientation.Vertical,
@@ -42,17 +41,6 @@ const color = (_: T, i: number) => Object.values(props.categories)[i].color;
 const LegendPositionTop = computed(
   () => props.legendPosition === LegendPosition.Top
 );
-
-const tickIndices = computed(() =>
-  getDistributedIndices(props.data.length, props.xNumTicks)
-);
-
-const filteredDataByIndices = computed(() => {
-  if (!props.data?.length || !tickIndices || tickIndices.value.length === 0) {
-    return [];
-  }
-  return tickIndices.value.map((index) => props.data[index]);
-});
 
 const generateTooltip = computed(() => (d: T) => {
   if (typeof window === "undefined" || typeof document === "undefined") {
@@ -93,7 +81,7 @@ const generateTooltip = computed(() => (d: T) => {
 
       <VisGroupedBar
         v-if="!stacked"
-        :data="filteredDataByIndices"
+        :data="data"
         :x="(_: T, i: number) => i"
         :y="yAxis"
         :color="color"
@@ -104,7 +92,7 @@ const generateTooltip = computed(() => (d: T) => {
       />
       <VisStackedBar
         v-else
-        :data="filteredDataByIndices"
+        :data="data"
         :x="(_: T, i: number) => i"
         :y="yAxis"
         :color="color"
@@ -115,12 +103,13 @@ const generateTooltip = computed(() => (d: T) => {
       />
       <VisAxis
         type="x"
-        :num-ticks="filteredDataByIndices.length"
-        :tick-format="props.orientation === Orientation.Horizontal ? xFormatter : (i: number, idx: number) => xFormatter(filteredDataByIndices[i], idx)"
+        :tick-format="xFormatter"
         :label="xLabel"
         :grid-line="xGridLine"
         :domain-line="xDomainLine"
         :tick-line="xTickLine"
+        :num-ticks="xNumTicks"
+        :tick-values="xExplicitTicks"
       />
       <VisAxis
         type="y"

--- a/lib/components/BarChart/types.ts
+++ b/lib/components/BarChart/types.ts
@@ -34,7 +34,7 @@ export interface BarChartProps<T> {
    * @param idx The index of the data point.
    * @returns The formatted x-axis label.
    */
-  xFormatter: (item: T, idx: number) => string | number;
+  xFormatter: (i: number, idx: number) => string | number;
   /**
    * An optional function that formats the y-axis tick labels.
    * @param i The value to be formatted.
@@ -50,6 +50,10 @@ export interface BarChartProps<T> {
    * The desired number of ticks on the x-axis.
    */
   xNumTicks?: number;
+  /**
+   * Force specific ticks on the x-axis.
+   */
+  xExplicitTicks?: number;
   /**
    * An array of property keys from the data object type 'T' to be used for the y-axis values.
    */

--- a/lib/components/LineChart/LineChart.vue
+++ b/lib/components/LineChart/LineChart.vue
@@ -14,7 +14,6 @@ import {
 import Tooltip from "./../Tooltip.vue";
 import { LegendPosition } from "../../types";
 import { LineChartProps } from "./types";
-import { getDistributedIndices } from "../../utils";
 
 const props = withDefaults(defineProps<LineChartProps<T>>(), {
   xNumTicks: (props) =>
@@ -51,17 +50,6 @@ const generateTooltip = computed(() => (d: T) => {
 const LegendPositionTop = computed(
   () => props.legendPosition === LegendPosition.Top
 );
-
-const tickIndices = computed(() =>
-  getDistributedIndices(props.data.length, props.xNumTicks)
-);
-
-const filteredDataByIndices = computed(() => {
-  if (!props.data?.length || !tickIndices || tickIndices.value.length === 0) {
-    return [];
-  }
-  return tickIndices.value.map((index) => props.data[index]);
-});
 </script>
 
 <template>
@@ -69,7 +57,7 @@ const filteredDataByIndices = computed(() => {
     class="flex flex-col space-y-4"
     :class="{ 'flex-col-reverse': LegendPositionTop }"
   >
-    <VisXYContainer :data="filteredDataByIndices" :height="height">
+    <VisXYContainer :data="data" :height="height">
       <VisTooltip
         :horizontal-placement="Position.Right"
         :vertical-placement="Position.Top"
@@ -84,13 +72,14 @@ const filteredDataByIndices = computed(() => {
       </template>
       <VisAxis
         type="x"
-        :num-ticks="filteredDataByIndices.length"
-        :tick-format="(i: number, idx: number) => xFormatter(filteredDataByIndices[i], idx)"
+        :tick-format="xFormatter"
         :label="xLabel"
         :label-margin="8"
         :domain-line="xDomainLine"
         :grid-line="xGridLine"
         :tick-line="xTickLine"
+        :num-ticks="xNumTicks"
+        :tick-values="xExplicitTicks"
       />
       <VisAxis
         type="y"

--- a/lib/components/LineChart/types.ts
+++ b/lib/components/LineChart/types.ts
@@ -60,6 +60,10 @@ export interface LineChartProps<T> {
    */
   xNumTicks?: number;
   /**
+   * Force specific ticks on the x-axis.
+   */
+  xExplicitTicks?: number;
+  /**
    * If `true`, hides the chart legend.
    */
   hideLegend?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-chrts",
-  "version": "0.1.0-beta.2",
+  "version": "0.1.0-beta.3",
   "type": "module",
   "files": [
     "dist"

--- a/src/AreaChartPage.vue
+++ b/src/AreaChartPage.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import Card from "./elements/Card.vue";
 
-import { CurveType, LegendPosition } from './../lib/types'
+import { AreaChart, AreaStackedChart } from './../lib'
+import { CurveType, LegendPosition } from "./../lib/types";
 
 import {
   AreaChartData1,
@@ -11,7 +12,6 @@ import {
   AreaChartItem1,
   categories1,
   categories2,
-  categories3,
   categories4,
   categories5,
 } from "./data/AreaChartData";
@@ -74,7 +74,11 @@ import {
         <template #header>
           <h2 class="text-xl my-2 font-bold">Area Chart Stacked</h2>
         </template>
-        <AreaStackedChart :height="200" :data="AreaChartData3" :categories="categories4" />
+        <AreaStackedChart
+          :height="200"
+          :data="AreaChartData3"
+          :categories="categories4"
+        />
       </Card>
 
       <Card>

--- a/src/BarChartPage.vue
+++ b/src/BarChartPage.vue
@@ -106,9 +106,8 @@ const RevenueCategoriesMultple = {
           :height="250"
           :categories="RevenueCategoriesMultple"
           :y-axis="['desktop']"
-          :xNumTicks="6"
           :radius="4"
-          :x-formatter="(item): string => `${item?.month }`"
+          :x-formatter="(i: number): string => `${RevenueData[i]?.month }`"
           :y-formatter="(i: number) => i"
           :legend-position="LegendPosition.Top"
         />
@@ -146,9 +145,8 @@ const RevenueCategoriesMultple = {
           :y-axis="['desktop', 'mobile']"
           :group-padding="0"
           :bar-padding="0.2"
-          :xNumTicks="6"
           :radius="4"
-          :x-formatter="(item): string => `${item?.month }`"
+          :x-formatter="(i: number): string => `${RevenueData[i]?.month }`"
           :y-formatter="(i: number) => i"
           :legend-position="LegendPosition.Top"
         />
@@ -169,7 +167,7 @@ const RevenueCategoriesMultple = {
           :bar-padding="0.2"
           :xNumTicks="6"
           :radius="4"
-          :x-formatter="(item): string => `${item?.month }`"
+          :x-formatter="(i: number): string => `${RevenueData[i]?.month }`"
           :y-formatter="(i: number) => i"
           :legend-position="LegendPosition.Top"
         />
@@ -187,11 +185,11 @@ const RevenueCategoriesMultple = {
           :y-axis="['visitors']"
           :x-num-ticks="6"
           :radius="4"
-          :x-formatter="(item): string => {
-            if(!item?.date) {
+          :x-formatter="(i: number): string => {
+            if(!VisitorsData[i]?.date) {
               return '';
             }
-            const date = new Date(item.date)
+            const date = new Date(VisitorsData[i].date)
               return date.getMonth() + 1 + '/' + date.getDate() + '/' + date.getFullYear();
             }"
           :y-formatter="(i: number) => i"
@@ -215,7 +213,7 @@ const RevenueCategoriesMultple = {
           :xNumTicks="6"
           :radius="4"
           :orientation="Orientation.Horizontal"
-          :x-formatter="(i) => i.toString()"
+          :x-formatter="(i) => i"
           :y-formatter="(i: number): string => `${RevenueData[i].month }`"
           :legend-position="LegendPosition.Top"
         />
@@ -228,10 +226,9 @@ const RevenueCategoriesMultple = {
         :height="358"
         :categories="RevenueCategories"
         :y-axis="['value']"
-        :x-num-ticks="RevenueDataLong.length"
         :hide-legend="true"
         :y-formatter="(i: number) => i"
-        :x-formatter="(i, idx): string => idx % 6 === 0 || idx === RevenueDataLong.length -1 ?  i.date: ''"
+        :x-formatter="(i) => RevenueDataLong[i].date"
       />
     </div>
   </div>


### PR DESCRIPTION
Revert to explicit x-axis tick settings. This undoes the attempt to derive exact ticks, which proved unreliable