### PR TITLE
Correct typing of xExplicitTicks

### DIFF
--- a/packages/vue/lib/components/AreaChart/types.ts
+++ b/packages/vue/lib/components/AreaChart/types.ts
@@ -74,7 +74,7 @@ export interface AreaChartProps<T> {
   /**
    * Force specific ticks on the x-axis.
    */
-  xExplicitTicks?: number;
+  xExplicitTicks?: (number | string | Date)[];
   /**
    * Force only first and last ticks on the x-axis.
    */

--- a/packages/vue/lib/components/BarChart/types.ts
+++ b/packages/vue/lib/components/BarChart/types.ts
@@ -68,7 +68,7 @@ type BarChartPropsBase<T> = {
   /**
    * Force specific ticks on the x-axis.
    */
-  xExplicitTicks?: number;
+  xExplicitTicks?: (number | string | Date)[];
   /**
    * An array of property keys from the data object type 'T' to be used for the y-axis values.
    */

--- a/packages/vue/lib/components/LineChart/types.ts
+++ b/packages/vue/lib/components/LineChart/types.ts
@@ -80,7 +80,7 @@ export interface LineChartProps<T> {
   /**
    * Force specific ticks on the x-axis.
    */
-  xExplicitTicks?: number;
+  xExplicitTicks?: (number | string | Date)[];
   /**
    * Force only first and last ticks on the x-axis.
    */


### PR DESCRIPTION
They were only correct for BubbleChart.