### PR TITLE
feat: add labels to donut chart tooltip like other chart types

### DIFF
--- a/packages/vue/lib/components/Tooltip.vue
+++ b/packages/vue/lib/components/Tooltip.vue
@@ -20,7 +20,7 @@ const visibleEntries = computed(() => {
 </script>
 
 <template>
-  <div style="padding: 10px 15px;">
+  <div style="padding: 10px 15px">
     <div
       :style="{
         color: 'var(--tooltip-value-color)',
@@ -40,9 +40,10 @@ const visibleEntries = computed(() => {
       <span
         style="width: 8px; height: 8px; border-radius: 4px; margin-right: 8px"
         :style="{
-          backgroundColor: typeof categories[key]?.color === 'string' && categories[key]?.color
-            ? categories[key].color
-            : `var(--vis-color${index})`,
+          backgroundColor:
+            typeof categories[key]?.color === 'string' && categories[key]?.color
+              ? categories[key].color
+              : `var(--vis-color${index})`,
         }"
       ></span>
       <div>
@@ -54,7 +55,7 @@ const visibleEntries = computed(() => {
         <span
           style="font-weight: 400"
           :style="{ color: 'var(--tooltip-value-color)' }"
-          >{{ yFormatter ? yFormatter(value) : value  }}</span
+          >{{ yFormatter ? yFormatter(value) : value }}</span
         >
       </div>
     </div>

--- a/packages/vue/src/AreaChartPage.vue
+++ b/packages/vue/src/AreaChartPage.vue
@@ -688,7 +688,9 @@ function handleChartClick(event: MouseEvent, hoverValues: any) {
       strokeColor: 'blue',
     }"
     @click="handleChartClick"
-  />
+  >
+   <template #tooltip="{ values }">{{  values }}</template>
+  </AreaChart>
 
     <!-- Use a container div for the grid to apply potential flex properties -->
     <div class="max-w-screen-2xl mx-auto py-4 px-4 sm:px-6 lg:px-8">

--- a/packages/vue/src/DonutChartPage.vue
+++ b/packages/vue/src/DonutChartPage.vue
@@ -32,7 +32,9 @@ function handleChartClick(event: MouseEvent, hoverValues: any) {
         <div class="text-center">
           <div class="font-semibold">La123123123123bel</div>
           <div class="text-muted">2 seconds ago</div>
-        </div></DonutChart
+        </div>
+        
+        </DonutChart
       >
 
       <Card>

--- a/packages/vue/src/data/DonutChartData.ts
+++ b/packages/vue/src/data/DonutChartData.ts
@@ -1,6 +1,8 @@
+import type { BulletLegendItemInterface } from '@unovis/ts'
 export const DonutChartData = [30, 70, 100];
-export const DonutCategories = [
-  { name: 'A', color: '#3b82f6' },
-  { name: 'B', color: '#22c55e' },
-  { name: 'C', color: '#f59e42' },
-];
+
+export const DonutCategories: Record<string, BulletLegendItemInterface> = {
+  a: { name: 'a', color: '#3b82f6' },
+  b: { name: 'b', color: '#22c55e' },
+  c: { name: 'c', color: '#f59e42' }
+}


### PR DESCRIPTION
Fixes: https://github.com/dennisadriaans/vue-chrts/issues/52

Use the default Tooltip for the Donut Chart to render the label identically to other chart types

This is a breaking change.