### PR TITLE
fix: add support for multple charts with marker configs

### DIFF
--- a/packages/vue/lib/components/AreaChart/AreaChart.vue
+++ b/packages/vue/lib/components/AreaChart/AreaChart.vue
@@ -55,7 +55,7 @@ const colors = computed(() => {
 });
 
 const markersSvgDefs = computed(() => {
-  if (!props.markerConfig) return "";
+  if (!props.markerConfig?.config) return "";
   return createMarkers(props.markerConfig);
 });
 
@@ -137,7 +137,7 @@ function onCrosshairUpdate(d: T): string {
       flexDirection: isLegendTop ? 'column-reverse' : 'column',
       gap: 'var(--vis-legend-spacing)',
     }"
-    :class="{ markers: !!props.markerConfig }"
+    :id="markerConfig?.id"
     @click="emit('click', $event, hoverValues)"
   >
     <VisXYContainer

--- a/packages/vue/lib/components/AreaChart/types.ts
+++ b/packages/vue/lib/components/AreaChart/types.ts
@@ -39,7 +39,7 @@ export interface AreaChartProps<T> {
   /**
    * A record mapping marker keys to show custom patterns.
    */
-  markerConfig?: Record<string, MarkerConfig>;
+  markerConfig?: MarkerConfig;
   /**
    * A function that formats the x-axis tick labels.
    */

--- a/packages/vue/lib/types.ts
+++ b/packages/vue/lib/types.ts
@@ -84,13 +84,18 @@ export interface AxisConfig {
   tickValues?: readonly number[] | readonly Date[];
 }
 
-export interface MarkerConfig {
-  type?: "circle" | "square" | "triangle" | "diamond";
-  size?: number;
-  strokeWidth?: number;
-  color?: string;
-  strokeColor?: string;
-}
+export type MarkerConfig = {
+  id: string,
+  config: {
+    [key: string]: {
+    type?: "circle" | "square" | "triangle" | "diamond";
+    size?: number;
+    strokeWidth?: number;
+    color?: string;
+    strokeColor?: string;
+  };
+  }
+};
 
 export interface CrosshairConfig {
   color?: string;

--- a/packages/vue/lib/utils.ts
+++ b/packages/vue/lib/utils.ts
@@ -76,15 +76,15 @@ export const markerShape = (
   }
 };
 
-export function createMarkers(markerConfig: Record<string, MarkerConfig>) {
-  return Object.entries(markerConfig)
+export function createMarkers(markerConfig: MarkerConfig) {
+  return Object.entries(markerConfig.config)
     .map(([key, cfg]) => {
       const type = cfg.type || "circle";
       const size = cfg.size || 10;
       const strokeWidth = cfg.strokeWidth || 2;
       const color = cfg.color || "#000";
       const strokeColor = cfg.strokeColor || cfg.color || "#000";
-      return `<marker id="circle-marker-${key}" viewBox="0 0 ${size} ${size}" refX="${
+      return `<marker id="${markerConfig.id}-${key}" viewBox="0 0 ${size} ${size}" refX="${
         size / 2
       }" refY="${size / 2}" markerWidth="${size / 2}" markerHeight="${
         size / 2


### PR DESCRIPTION
BREAKING CHANGE: The `MarkerConfig` object has changed and requires an ID to work correctly.