### PR TITLE
feat(BarChart): add xDomain/yDomain props and fix value labels positioning

### DIFF
--- a/packages/vue/lib/components/BarChart/BarChart.ts
+++ b/packages/vue/lib/components/BarChart/BarChart.ts
@@ -165,6 +165,14 @@ export type BarChartPropsBase<T> = {
    */
   yAxisConfig?: AxisConfig;
   /**
+   * Fixed X scale domain as [min, max].
+   */
+  xDomain?: [number, number] | [Date, Date];
+  /**
+   * Fixed Y scale domain as [min, max].
+   */
+  yDomain?: [number, number] | [Date, Date];
+  /**
    * Animation duration in milliseconds for the chart components.
    */
   duration?: number;

--- a/packages/vue/lib/components/BarChart/BarChart.vue
+++ b/packages/vue/lib/components/BarChart/BarChart.vue
@@ -141,6 +141,11 @@ const labelX = (d: LabelDatum) => {
   return d.x + offsetFromCenter;
 };
 
+const isHorizontal = (props.orientation ?? Orientation.Vertical) === Orientation.Horizontal;
+
+const labelValue = (d: LabelDatum) =>
+  d.y + (props.valueLabel?.labelSpacing ?? 0) * (d.y < 0 ? -1 : 1);
+
 </script>
 
 <template>
@@ -156,15 +161,14 @@ const labelX = (d: LabelDatum) => {
       :padding="padding"
       :height="height"
       :duration="duration"
+      :xDomain="xDomain"
+      :yDomain="yDomain"
     >
       <VisXYLabels
         v-if="!!valueLabel"
         :data="labelData"
-        :x="labelX"
-        :y="
-          (d: any) =>
-            d.y + (props.valueLabel?.labelSpacing ?? 0) * (d.y < 0 ? -1 : 1)
-        "
+        :x="isHorizontal ? labelValue : labelX"
+        :y="isHorizontal ? labelX : labelValue"
         :label="props.valueLabel?.label"
         :backgroundColor="props.valueLabel?.backgroundColor ?? 'transparent'"
         :color="props.valueLabel?.color ?? 'red'"
@@ -250,7 +254,7 @@ const labelX = (d: LabelDatum) => {
         v-bind="yAxisConfig"
       />
     </VisXYContainer>
-    
+
     <div
       v-if="!props.hideLegend"
       :style="{
@@ -271,7 +275,7 @@ const labelX = (d: LabelDatum) => {
         "
       />
     </div>
-    
+
     <div ref="slotWrapper" style="display: none">
       <slot v-if="slots.tooltip" name="tooltip" :values="hoverValues" />
       <slot v-else-if="hoverValues" name="fallback">


### PR DESCRIPTION
## What

Adds `xDomain` and `yDomain` props to `BarChart` and fixes value label placement when `orientation` is `Horizontal`.

## Why

- Without a way to fix the scale domain, users have no control over axis ranges. This is useful for keeping consistent axes across multiple charts side-by-side, or for clamping the visible range to a specific window of data.
- Value labels on horizontal bar charts were mapped to the wrong axis, causing them to render above bars instead of in front of them.

## Changes

- `xDomain` and `yDomain` are forwarded directly to `VisXYContainer`, which already supports both natively.
- Extracted a shared `labelValue` accessor and an `isHorizontal` flag. When horizontal, the `x` and `y` bindings on `VisXYLabels` are swapped so labels track the value axis correctly.
- `labelValue` handles negative bar values correctly — spacing is applied away from zero regardless of sign.

## Usage
**Vertical bars — setting the Y (value) axis range:**
```vue
<BarChart
  :data="data"
  :categories="{ revenue: { label: 'Revenue', color: 'blue' } }"
  :yAxis="['revenue']"
  :height="300"
  :yDomain="[0, 10000]"
/>
```

**Horizontal bars — setting the X (value) axis range:**
```vue
<BarChart
  :data="data"
  :categories="{ score: { label: 'Score', color: 'green' } }"
  :yAxis="['score']"
  :height="300"
  :orientation="Orientation.Horizontal"
  :xDomain="[0, 100]"
/>
```