### PR TITLE
feat(charts): pass xDomain/yDomain through to VisXYContainer

### DIFF
--- a/packages/vue/lib/components/BarChart/BarChart.ts
+++ b/packages/vue/lib/components/BarChart/BarChart.ts
@@ -167,11 +167,11 @@ export type BarChartPropsBase<T> = {
   /**
    * Fixed X scale domain as [min, max].
    */
-  xDomain?: [number, number] | [Date, Date];
+  xDomain?: [number | undefined, number | undefined];
   /**
    * Fixed Y scale domain as [min, max].
    */
-  yDomain?: [number, number] | [Date, Date];
+  yDomain?: [number | undefined, number | undefined];
   /**
    * Animation duration in milliseconds for the chart components.
    */

--- a/packages/vue/lib/components/BubbleChart/BubbleChart.ts
+++ b/packages/vue/lib/components/BubbleChart/BubbleChart.ts
@@ -178,4 +178,12 @@ export interface BubbleChartProps<T> {
    * Configuration object for the chart tooltip.
    */
   tooltip?: TooltipConfig;
+  /**
+   * Fixed X scale domain as [min, max].
+   */
+  xDomain?: [number | undefined, number | undefined];
+  /**
+   * Fixed Y scale domain as [min, max].
+   */
+  yDomain?: [number | undefined, number | undefined];
 }

--- a/packages/vue/lib/components/BubbleChart/BubbleChart.vue
+++ b/packages/vue/lib/components/BubbleChart/BubbleChart.vue
@@ -128,6 +128,8 @@ const legendAlignment = computed(() => {
       :padding="props.padding"
       :duration="duration"
       :scaleByDomain="true"
+      :x-domain="props.xDomain"
+      :y-domain="props.yDomain"
       @click="emit('click', $event, hoverValues)"
     >
       <VisTooltip

--- a/packages/vue/lib/components/DualChart/DualChart.vue
+++ b/packages/vue/lib/components/DualChart/DualChart.vue
@@ -128,6 +128,8 @@ function onCrosshairUpdateWithContent(d: T): string {
       :height="height"
       :duration="duration"
       :data="data"
+      :x-domain="xDomain"
+      :y-domain="yDomain"
     >
       <VisTooltip
         v-if="!hideTooltip"

--- a/packages/vue/lib/components/GanttChart/GanttChart.ts
+++ b/packages/vue/lib/components/GanttChart/GanttChart.ts
@@ -134,4 +134,12 @@ export interface GanttChartProps<T> {
    * Configuration object for the chart tooltip.
    */
   tooltip?: TooltipConfig;
+  /**
+   * Fixed X scale domain as [min, max].
+   */
+  xDomain?: [number | undefined, number | undefined];
+  /**
+   * Fixed Y scale domain as [min, max].
+   */
+  yDomain?: [number | undefined, number | undefined];
 }

--- a/packages/vue/lib/components/GanttChart/GanttChart.vue
+++ b/packages/vue/lib/components/GanttChart/GanttChart.vue
@@ -90,6 +90,8 @@ const colors = computed(() => {
       :data="props.data"
       :height="props.height"
       :duration="duration"
+      :x-domain="props.xDomain"
+      :y-domain="props.yDomain"
       @wheel="handleScroll"
     >
       <VisTimeline


### PR DESCRIPTION
- BubbleChart, GanttChart: declare xDomain/yDomain on the props interface and bind them on VisXYContainer (was missing entirely).
- DualChart: bind already-declared xDomain/yDomain on VisXYContainer (props were declared but the template never bound them — silent no-op).
- BarChart: narrow xDomain/yDomain to [number | undefined, number | undefined] to match @unovis/ts 1.6.4 (was [number, number] | [Date, Date], added in PR #125 and merged to main but not yet released on npm).

Note on d3 vs unovis: d3 itself does accept Date for time scales —

    // @types/d3-scale ScaleTime.domain()
    domain(domain: Iterable<Date | NumberValue>): this;

— and `[Date, Date]` works at runtime because Date.prototype.valueOf() returns epoch ms, so d3's scale silently coerces each Date to a number. But @unovis/ts 1.6.4 declares the container-level config as:

    // @unovis/ts XYContainerConfigInterface
    xDomain?: [number | undefined, number | undefined];
    yDomain?: [number | undefined, number | undefined];

The narrowed BarChart type mirrors the unovis type rather than relying on undocumented coercion — same runtime behavior, no wrapper/library type mismatch. Users passing date bounds can use Date.getTime().